### PR TITLE
Add window2016 as a valid stack for hwc

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -26,4 +26,5 @@ dependencies:
   md5: acb65777be759df87d7d288146d592f7
   cf_stacks:
   - windows2012R2
+  - windows2016
 pre_package: scripts/build.sh


### PR DESCRIPTION
Note that this depends on: https://github.com/cloudfoundry/buildpack-packager/pull/15 being merged + a new version of buildpack packager being released

Side note: the greenhouse github team still has admin access to this repo